### PR TITLE
add back intent filter to recieve urls via 'share'

### DIFF
--- a/passwordmaker/src/main/AndroidManifest.xml
+++ b/passwordmaker/src/main/AndroidManifest.xml
@@ -12,9 +12,14 @@
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter android:label="Open In PWM">
+              <action android:name="android.intent.action.SEND" />
+              <category android:name="android.intent.category.DEFAULT" />
+              <data android:mimeType="text/plain" />
+            </intent-filter>
+
         </activity>
         <activity
             android:name="org.passwordmaker.android.AccountListActivity"


### PR DESCRIPTION
Re-fixes issue #2 so that urls can be shared from eg. a web browser to pre-populate the url.
Sorry UN-tested because I'm used to using Ant so I couldn't manage to convince gradle to actually do a build :-(
