### PR TITLE
Use an empty string instead of account's name for "Use Text" option for ...

### DIFF
--- a/passwordmaker/src/main/java/org/passwordmaker/android/AccountListFragment.java
+++ b/passwordmaker/src/main/java/org/passwordmaker/android/AccountListFragment.java
@@ -262,7 +262,7 @@ public class AccountListFragment extends ListFragment {
             account.setName(accountName);
             account.setIsFolder(false);
             account.clearUrlComponents();
-            account.setUrl(accountName);
+            account.addUrlComponent(Account.UrlComponents.Domain);
             account.getPatterns().clear();
             accountManager.getPwmProfiles().addAccount(accountStack.getCurrentAccount(), account);
             getCurrentAccountList().notifyDataSetChanged();


### PR DESCRIPTION
I were wondering why Password Maker was generating a wrong password. It turned out that when you create a profile (an account) it sets "Use Text" field to account's name by default. And if you don't clear it, it will be used as an input text for generating the password.

generatePassword function calls getModifiedInputText function. The latter ignores inputText parameter if account's url field is set and uses its value as the input text.