### PR TITLE
Issue #41 - bug fix where android 9 instant crash due to BC algorithms being removed.

### DIFF
--- a/passwordmaker/build.gradle
+++ b/passwordmaker/build.gradle
@@ -90,7 +90,7 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     implementation 'com.intellij:annotations:12.0@jar'
-    implementation 'org.passwordmaker:passwordmaker-je-lib:0.9.9'
+    implementation 'org.passwordmaker:passwordmaker-je-lib:0.9.10'
     implementation 'com.madgag.spongycastle:core:1.50.0.0'
     implementation 'com.madgag.spongycastle:prov:1.50.0.0'
     implementation 'com.google.guava:guava:27.0.1-android'

--- a/passwordmaker/src/main/java/org/passwordmaker/android/PwmApplication.java
+++ b/passwordmaker/src/main/java/org/passwordmaker/android/PwmApplication.java
@@ -57,9 +57,9 @@ public class PwmApplication {
     }
 
     private PwmApplication() {
-        accountManager = new AccountManager();
         PasswordMaker.setDefaultCryptoProvider("SC");
         Security.insertProviderAt(new org.spongycastle.jce.provider.BouncyCastleProvider(), 1);
+        accountManager = new AccountManager();
         AccountManagerSamples.addSamples(accountManager);
     }
 


### PR DESCRIPTION
See https://android-developers.googleblog.com/2018/03/cryptography-changes-in-android-p.html for more details.